### PR TITLE
Add in custom root_patterns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ wiki](https://github.com/ckipp01/nvim-metals/wiki/Try-nvim-metals-without-confli
   - [Settings and Mappings](#settings-and-mappings)
       - [Custom Mappings](#custom-mappings)
   - [Available Commands](#available-commands)
+  - [Custom Functions](#custom-functions)
   - [Custom Callbacks](#custom-callbacks)
   - [Statusline Integration](#statusline-integration)
   - [Complementary Plugins](#complementary-plugins)
@@ -217,6 +218,29 @@ Command             |Description
 `:MetalsDoctor`     | Run Metals Doctor, which will open in your browser
 `:MetalsLogsToggle` | Opens the embedded terminal to view metals logs
 `:SourcesScan`      | Scan all workspace sources
+
+## Custom Functions
+
+Custom functions are similar to Custom Callbacks in that you use them to
+override a default setup option for Metals.
+
+Currently if you use an build definition structure with multiple nested build
+files, the Nvim LSP client will re-initialize when you go into a module with
+another build file. In order to prevent this, use the `metals.root_pattern()`
+function to override the `root_dir` function like below:
+
+```lua
+local metals = require'metals'
+nvim_lsp.metals.setup{
+  root_dir = metals.root_pattern("build.sbt", "build.sc");
+}
+```
+
+This `root_patter()` function is almost identical to the one that is in
+`nvim-lsp`, but it adds in the ability to check to ensure that there isn't
+another build file in the parent directory. If you are only using nvim-metals
+with projects that only ever have one build file, then there is no need to set
+this.
 
 ## Custom Callbacks
 

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -118,9 +118,24 @@ logs_toggle()             Use to trigger a |tail -f .metals/log| on your current
                                                                 *sources_scan()*
 sources_scan()            Use to execute a |metals.sources-scan| command.
 
-                                                                *sources_scan()*
-sources_scan()            Use to execute a |metals.sources-scan| command.
+                                                                *root_pattern()*
+root_pattern({target_build_files})
+                          Used to override the default |root_dir| function in
+                          nvim-lsp. The default does not take into accoun the
+                          possiblity of nested build files.
 
+                          Parameters:
+                          {target_build_files} Build files you'd like to be
+                          recognized.
+
+
+You use this be overriding the default |root_dir| like below:
+>
+local metals = require'metals'
+nvim_lsp.metals.setup{
+  root_dir = metals.root_pattern("build.sbt", "build.sc");
+}
+<
 ================================================================================
 CUSTOM CALLBACKS                                       *metals-custom-callbacks*
 

--- a/lua/metals/util.lua
+++ b/lua/metals/util.lua
@@ -1,0 +1,123 @@
+local validate = vim.validate
+local uv = vim.loop
+
+local M = {}
+
+M.search_ancestors = function(startpath, func)
+  validate { func = {func, 'f'} }
+  if func(startpath) then return startpath end
+  for path in M.path.iterate_parents(startpath) do
+    if func(path) then return path end
+  end
+end
+
+-- Some path utilities
+-- This is taken verbatim from nvim-lsp, but since I don't want to directly
+-- require their utils module in here, it lives here for the time being.
+-- https://github.com/neovim/nvim-lsp/blob/master/lua/nvim_lsp/util.lua
+M.path = (function()
+  local function exists(filename)
+    local stat = uv.fs_stat(filename)
+    return stat and stat.type or false
+  end
+
+  local function is_dir(filename)
+    return exists(filename) == 'directory'
+  end
+
+  local function is_file(filename)
+    return exists(filename) == 'file'
+  end
+
+  local is_windows = uv.os_uname().version:match("Windows")
+  local path_sep = is_windows and "\\" or "/"
+
+  local is_fs_root
+  if is_windows then
+    is_fs_root = function(path)
+      return path:match("^%a:$")
+    end
+  else
+    is_fs_root = function(path)
+      return path == "/"
+    end
+  end
+
+  local dirname
+  do
+    local strip_dir_pat = path_sep.."([^"..path_sep.."]+)$"
+    local strip_sep_pat = path_sep.."$"
+    dirname = function(path)
+      if not path then return end
+      local result = path:gsub(strip_sep_pat, ""):gsub(strip_dir_pat, "")
+      if #result == 0 then
+        return "/"
+      end
+      return result
+    end
+  end
+
+  local function path_join(...)
+    local result =
+      table.concat(
+        vim.tbl_flatten {...}, path_sep):gsub(path_sep.."+", path_sep)
+    return result
+  end
+
+  -- Traverse the path calling cb along the way.
+  local function traverse_parents(path, cb)
+    path = uv.fs_realpath(path)
+    local dir = path
+    -- Just in case our algo is buggy, don't infinite loop.
+    for _ = 1, 100 do
+      dir = dirname(dir)
+      if not dir then return end
+      -- If we can't ascend further, then stop looking.
+      if cb(dir, path) then
+        return dir, path
+      end
+      if is_fs_root(dir) then
+        break
+      end
+    end
+  end
+
+  -- Iterate the path until we find the rootdir.
+  local function iterate_parents(path)
+    path = uv.fs_realpath(path)
+    local function it(_, v)
+      if not v then return end
+      if is_fs_root(v) then return end
+      return dirname(v), path
+    end
+    return it, path, path
+  end
+
+  local function is_descendant(root, path)
+    if (not path) then
+      return false;
+    end
+
+    local function cb(dir, _)
+      return dir == root;
+    end
+
+    local dir, _ = traverse_parents(path, cb);
+
+    return dir == root;
+  end
+
+  return {
+    is_dir = is_dir;
+    is_file = is_file;
+    exists = exists;
+    sep = path_sep;
+    dirname = dirname;
+    join = path_join;
+    traverse_parents = traverse_parents;
+    iterate_parents = iterate_parents;
+    is_descendant = is_descendant;
+  }
+end)()
+
+return M

--- a/nvim-lsp.vim
+++ b/nvim-lsp.vim
@@ -29,8 +29,8 @@ nnoremap <silent> <leader>f   <cmd>lua vim.lsp.buf.formatting()<CR>
 "-----------------------------------------------------------------------------
 " nvim-lsp Settings
 "-----------------------------------------------------------------------------
-" If you just use the latest sbatle version, then this setting isn't necessary
-let g:metals_server_version = '0.8.4+106-5f2b9350-SNAPSHOT'
+" If you just use the latest stable version, then this setting isn't necessary
+let g:metals_server_version = '0.9.0+18-27d4652a-SNAPSHOT'
 
 " This is needed to enable completions
 autocmd FileType scala setlocal omnifunc=v:lua.vim.lsp.omnifunc
@@ -43,10 +43,9 @@ let g:LspDiagnosticsWarningSign = ''
 "-----------------------------------------------------------------------------
 " lua callbacks
 "-----------------------------------------------------------------------------
-" NOTE: this is a bit verbose, but it easily allows you to add more to it, which
-" is the reason why it's done this way.
 :lua << EOF
   local nvim_lsp = require'nvim_lsp'
+  local metals = require'metals'
   local M = {}
 
   M.on_attach = function()
@@ -55,7 +54,11 @@ let g:LspDiagnosticsWarningSign = ''
     end
 
   nvim_lsp.metals.setup{
-    on_attach = M.on_attach,
+    on_attach = M.on_attach;
+    root_dir = metals.root_pattern("build.sbt", "build.sc");
+    callbacks = {
+      ["textDocument/hover"] = metals.hover_wrap
+    };
   }
 EOF
 


### PR DESCRIPTION
The default `root_patterns()` function that nvim-lsp provides
is great, but for Scala there will be times where the user
is in a situation where they have nested build files for a
workspace. By default this won't work since the client will
re-initialize causing the root workspace to be wrong. This
custom `root_patterns()` function adds in an extra check to
make sure the parent directory doesn't also have a build file.

Fixes #5 