### PR TITLE
Add in ability to enable metals/status

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Currently, the following callbacks are available:
 Callback            |Description
 --------------------|-------------------------------------
 `hover_wrap()`      | The default floating window for hovers do not wrap for long text. This hover implementation will wrap for you.
+`metals_status()`   | Used as a callback to enable `metals/status`. In order to use this, you need to make sure you also override `statusBarProvider` to `on` in your `init_options`.
 
 ## Statusline integration
 
@@ -307,6 +308,18 @@ do this all in one function, two functions, etc. Customize it to your liking.
 For me, I like a minimal statusline, so having this setup looks like this:
 
 ![Statusline](https://i.imgur.com/y4hij0S.png)
+
+You can also enable
+[`metals/status`](https://scalameta.org/metals/docs/editors/new-editor.html#metalsstatus)
+which will allow for you to use the `metals#status()` function in your
+statusline to show the status messages coming from Metals. This can be used like
+the below example or added into an existing statusline integration:
+
+```vim
+...
+set statusline+=%{metals#status()}\ " metals/status
+...
+```
 
 ## Complementary Plugins
 

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -12,6 +12,7 @@ CONTENTS                                                           *nvim-metals*
     2. Commands.............. |metals-commands|
     3. LUA API............... |metals-api|
     4. Custom Callbacks...... |metals-custom-callbacks|
+    5. Functions............. |metals-functions|
 
 ================================================================================
 INTRODUCTION                                                *metals-introdction*
@@ -130,6 +131,7 @@ root_pattern({target_build_files})
 
 You use this be overriding the default |root_dir| like below: >
 
+  local nvim_lsp = require'nvim_lsp'
   local metals = require'metals'
   nvim_lsp.metals.setup{
     root_dir = metals.root_pattern("build.sbt", "build.sc");
@@ -150,6 +152,7 @@ Example global usage: >
 
 Example usage for only Metals: >
 
+  local nvim_lsp = require'nvim_lsp'
   local metals = require'metals'
   nvim_lsp.metals.setup{
      callbacks = {
@@ -164,9 +167,49 @@ hover_wrap({err}, {method}, {result})
                           callback since the default doesn't wrap lines.
 
                           Parameters:
-                          {err}    Just ignored in this callback since
-                          {method} textDocument/hover in this case
+                          {err}    Hover error
+                          {method} textDocument/hover
                           {result} hover results from the server
 
+                                                               *metals_status()*
+metals_status({err}, {method}, {result})
+                          Used to override the default ["textDocument/hover"]
+                          callback since the default doesn't wrap lines.
+
+
+                          Parameters:
+                          {err}    Error
+                          {method} metals/status
+                          {result} MetalsStatusParams
+
+The spec for this can be found here:
+
+https://scalameta.org/metals/docs/editors/new-editor.html#metalsstatus
+
+If you are using this, you need to also override the default
+|StatusBarProvider| value in |init_options|. You'll also want to ensure that
+information is being displayed by your statusline by using the
+|metals#status()| function.
+>
+  local nvim_lsp = require'nvim_lsp'
+  local metals = require'metals'
+  nvim_lsp.metals.setup{
+    init_options = {
+      statusBarProvider = "on";
+    };
+    callbacks = {
+      ["metals/status"] = metals.metals_status;
+    };
+  }
+<
+================================================================================
+FUNCTIONS                                                     *metals-functions*
+
+                                                               *metals#status()*
+metals#status()           Able to be used in your statusline to show status
+                          messages from Metals. In order for this to be set,
+                          you need to ensure that |statusBarProvider| is set
+                          to |on|, and the |metals/status| callback is set to
+                          |metals_status|.
 
 vim:tw=80:ts=2:ft=help:

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -63,7 +63,6 @@ M.sources_scan = function()
   })
 end
 
-
 -- Thanks to @clason for this
 -- This can be used to override the default ["textDocument/hover"]
 -- in order to wrap the hover on long methods
@@ -110,6 +109,19 @@ M.root_pattern = function(...)
   end
   return function(startpath)
     return util.search_ancestors(startpath, matcher)
+  end
+end
+
+-- Callback function to handle `metals/status`
+-- This simply sets a global variable `metals_status` which can be easily
+-- picked up and used in a statusline.
+-- Command and Tooltip are not covered from the spec.
+-- https://scalameta.org/metals/docs/editors/new-editor.html#metalsstatus
+M.metals_status = function(_, _, params)
+  if params.hide then
+    vim.api.nvim_set_var('metals_status', '')
+  else
+    vim.api.nvim_set_var('metals_status', params.text)
   end
 end
 

--- a/nvim-lsp.vim
+++ b/nvim-lsp.vim
@@ -56,8 +56,14 @@ let g:LspDiagnosticsWarningSign = ''
   nvim_lsp.metals.setup{
     on_attach = M.on_attach;
     root_dir = metals.root_pattern("build.sbt", "build.sc");
+    init_options = {
+      -- If you set this, make sure to have the `metals#status()` function
+      -- in your statusline, or you won't see any status messages
+      statusBarProvider = "on";
+    };
     callbacks = {
-      ["textDocument/hover"] = metals.hover_wrap
+      ["textDocument/hover"] = metals.hover_wrap;
+      ["metals/status"] = metals.metals_status;
     };
   }
 EOF

--- a/plugin/metals.vim
+++ b/plugin/metals.vim
@@ -14,6 +14,10 @@ command! Format lua vim.lsp.buf.formatting()
 command! MetalsDoctor lua require'metals'.doctor_run()
 command! MetalsLogsToggle lua require'metals'.logs_toggle()
 
+function! metals#status() abort
+  return get(g:, 'metals_status', '')
+endfunction
+
 let &cpo = s:save_cpo
 unlet s:save_cpo
 


### PR DESCRIPTION
By default `statusBarProvider` is set to showMessage.
This allows a user to override this and set it to `on`,
which enables `metals/status`. Then you can use the
newly created `metals_status` function to answer the callback
for `metals/status`, and also access the `metals_status`
global variable to use in your statusline.

Closes #3 